### PR TITLE
v0.2.2 Fix orderToBytes parsing bug for OasisV3Market

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/exchange-wrappers",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/exchange-wrappers",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Collection of exchange wrapper contracts used by the dYdX Protocol",
   "main": "dist/js/src/index.js",
   "types": "dist/types/src/index.d.ts",

--- a/src/exchange_wrappers/OasisV3MatchingExchangeWrapper.ts
+++ b/src/exchange_wrappers/OasisV3MatchingExchangeWrapper.ts
@@ -5,7 +5,7 @@ import {
 } from '../types';
 import { OasisV3MatchingExchangeWrapper as Contract } from '../../migrations/deployed.json';
 
-export class OasisV3SimpleExchangeWrapper {
+export class OasisV3MatchingExchangeWrapper {
   private networkId: number;
 
   constructor(

--- a/src/exchange_wrappers/OasisV3MatchingExchangeWrapper.ts
+++ b/src/exchange_wrappers/OasisV3MatchingExchangeWrapper.ts
@@ -5,7 +5,7 @@ import {
 } from '../types';
 import { OasisV3MatchingExchangeWrapper as Contract } from '../../migrations/deployed.json';
 
-export class OasisV3MatchingExchangeWrapper {
+export class OasisV3SimpleExchangeWrapper {
   private networkId: number;
 
   constructor(
@@ -30,7 +30,7 @@ export class OasisV3MatchingExchangeWrapper {
     }
     const price = new BigNumber(order.maxPrice);
     const priceDenominator = new BigNumber('1e18');
-    const priceNumerator = price.times(priceDenominator);
+    const priceNumerator = price.times(priceDenominator).integerValue(BigNumber.ROUND_DOWN);
     return []
       .concat(this.toBytes(priceNumerator))
       .concat(this.toBytes(priceDenominator));


### PR DESCRIPTION
Previously could not hexify non-integer values of BN