### PR TITLE
v0.2.6: Fix BigNumber to hex issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/exchange-wrappers",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/exchange-wrappers",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Collection of exchange wrapper contracts used by the dYdX Protocol",
   "main": "dist/js/src/index.js",
   "types": "dist/types/src/index.d.ts",

--- a/src/exchange_wrappers/ZeroExV2MultiOrderExchangeWrapper.ts
+++ b/src/exchange_wrappers/ZeroExV2MultiOrderExchangeWrapper.ts
@@ -32,8 +32,9 @@ export class ZeroExV2MultiOrderExchangeWrapper {
         .concat(this.toBytes(zero));
     } else {
       const base = new BigNumber('1e18');
+      const numerator = base.times(multiOrder.maxPrice).integerValue(BigNumber.ROUND_CEIL);
       result = result
-        .concat(this.toBytes(base.times(multiOrder.maxPrice)))
+        .concat(this.toBytes(numerator))
         .concat(this.toBytes(base));
     }
     for (let i = 0; i < multiOrder.orders.length; i += 1) {


### PR DESCRIPTION

```Error: Error: [number-to-bn] while converting number "1010181412833333333.3367" to BN.js instance, error: invalid number value. Value must be an integer, hex string, BN or BigNumber instance. Note, decimals are not supported. Given value: "1010181412833333333.3367"
    at toBN (utils.js:69)
    at numberToHex (utils.js:263)
    at Object.toHex (utils.js:351)
    at ZeroExV2MultiOrderExchangeWrapper.toBytes (ZeroExV2MultiOrderExchangeWrapper.js:54)
    at ZeroExV2MultiOrderExchangeWrapper.orderToBytes (ZeroExV2MultiOrderExchangeWrapper.js:42)```