### PR TITLE
v0.2.8 Use Byzantium EVM version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/exchange-wrappers",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dydxprotocol/exchange-wrappers",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Collection of exchange wrapper contracts used by the dYdX Protocol",
   "main": "dist/js/src/index.js",
   "types": "dist/types/src/index.d.ts",

--- a/truffle.js
+++ b/truffle.js
@@ -56,6 +56,7 @@ module.exports = {
           enabled: true,
           runs: 10000
         },
+        evmVersion: 'byzantium',
       },
     },
   },


### PR DESCRIPTION
So that the compiled contracts can be used with `solidity-coverage`