### PR TITLE
Implement 0x Coordinator Exchange Wrapper

### DIFF
--- a/contracts/exchange-wrappers/ZeroExV2CoordinatorMultiOrderExchangeWrapper.sol
+++ b/contracts/exchange-wrappers/ZeroExV2CoordinatorMultiOrderExchangeWrapper.sol
@@ -1,0 +1,257 @@
+pragma solidity 0.5.9;
+pragma experimental ABIEncoderV2;
+
+import { SafeMath } from "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import { IExchange } from "../external/0x/v2/interfaces/IExchange.sol";
+import { ICoordinatorCore } from "../external/0x/v2/interfaces/ICoordinatorCore.sol";
+import { LibOrder } from "../external/0x/v2/libs/LibOrder.sol";
+import { LibZeroExTransaction } from "../external/0x/v2/libs/LibZeroExTransaction.sol";
+import { ExchangeWrapper } from "../interfaces/ExchangeWrapper.sol";
+import { TokenInteract } from "../lib/TokenInteract.sol";
+import { AdvancedTokenInteract } from "../lib/AdvancedTokenInteract.sol";
+
+/**
+ * @title ZeroExV2MultiOrderExchangeWrapper
+ * @author 0x
+ *
+ * dYdX ExchangeWrapper to interface with 0x Version 2.1 Coordinator contract. Sends multiple orders at once. Assumes no
+ * ZRX fees.
+ */
+contract ZeroExV2CoordinatorMultiOrderExchangeWrapper is
+    LibOrder,
+    LibZeroExTransaction,
+    ExchangeWrapper
+{
+    using SafeMath for uint256;
+    using TokenInteract for address;
+    using AdvancedTokenInteract for address;
+
+    // ============ Constants ============
+
+    // bytes4(keccak256("isValidWalletSignature(bytes32,address,bytes)"))
+    // The 0x Exchange v2.1 contract requires that this value is returned for a successful `Wallet` signature validation
+    bytes4 constant IS_VALID_WALLET_SIGNATURE_MAGIC_VALUE = 0xb0671381;
+
+    // Byte that represents the 0x Exchange v2.1 `Wallet` signature type
+    bytes constant WALLET_SIGNATURE_TYPE = hex"04";
+
+    // ============ Structs ============
+
+    struct TokenAmounts {
+        uint256 takerAmount;
+        uint256 makerAmount;
+    }
+
+    struct CoordinatorArgs {
+        Order[] orders;                           // orders for `marketSellOrdersNoThrow`
+        bytes[] orderSignatures;                  // maker signatures for each order
+        uint256 transactionSalt;                  // salt to facilitate randomness in ZeroExTransaction hash
+        uint256[] approvalExpirationTimeSeconds;  // timestamps at which Coordinator approvals expire
+        bytes[] approvalSignatures;               // signatures of Coordinators that approved the transaction
+    }
+
+    struct MakerTakerTokenBalances {
+        uint256 makerTokenBalance;
+        uint256 takerTokenBalance;
+    }
+
+    struct FillResults {
+        uint256 makerTokenFilledAmount;
+        uint256 takerTokenFilledAmount;
+    }
+
+    // ============ State Variables ============
+
+    // address of the ZeroEx V2.1 Coordinator
+    address public ZERO_EX_COORDINATOR;
+
+    // address of the ZeroEx V2 ERC20Proxy
+    address public ZERO_EX_TOKEN_PROXY;
+
+    // ============ Constructor ============
+    constructor(
+        address zeroExCoordinator,
+        address zeroExProxy
+    )
+        public
+    {
+        ZERO_EX_COORDINATOR = zeroExCoordinator;
+        ZERO_EX_TOKEN_PROXY = zeroExProxy;
+    }
+
+    // ============ Public Functions ============
+
+    /**
+     * Exchange some amount of takerToken for makerToken.
+     *
+     * @param  receiver             Address to set allowance on once the trade has completed
+     * @param  makerToken           Address of makerToken, the token to receive
+     * @param  takerToken           Address of takerToken, the token to pay
+     * @param  requestedFillAmount  Amount of takerToken being paid
+     * @param  orderData            Arbitrary bytes data for any information to pass to the exchange
+     * @return                      The amount of makerToken received
+     */
+    function exchange(
+        address /* tradeOriginator */,
+        address receiver,
+        address makerToken,
+        address takerToken,
+        uint256 requestedFillAmount,
+        bytes calldata orderData
+    )
+        external
+        returns (uint256)
+    {
+        // Ensure that the ERC20Proxy can take the takerTokens from this contract
+        takerToken.ensureAllowance(ZERO_EX_TOKEN_PROXY, requestedFillAmount);
+
+        (TokenAmounts memory priceRatio, CoordinatorArgs memory args) = abi.decode(
+            orderData,
+            (TokenAmounts, CoordinatorArgs)
+        );
+
+        // Query initial balances of makerToken and takerToken
+        // These should be 0 unless tokens were erroneously sent to this contract
+        MakerTakerTokenBalances memory initialBalances = getMakerTakerTokenBalances(makerToken, takerToken);
+    
+        // Encode data for `marketSellOrdersNoThrow`
+        bytes memory marketSellOrdersNoThrowData = abi.encodeWithSelector(
+            IExchange(address(0)).marketSellOrdersNoThrow.selector,
+            args.orders,
+            requestedFillAmount,
+            args.orderSignatures
+        );
+
+        // Construct ZeroExTransaction on behalf of this contract
+        ZeroExTransaction memory transaction = ZeroExTransaction({
+            salt: args.transactionSalt,
+            data: marketSellOrdersNoThrowData,
+            signerAddress: address(this)
+        });
+
+        // Call `marketSellOrdersNoThrow` through the Coordinator contract
+        // Either succeeds or throws
+        ICoordinatorCore(ZERO_EX_COORDINATOR).executeTransaction(
+            transaction,
+            tx.origin,
+            WALLET_SIGNATURE_TYPE,
+            args.approvalExpirationTimeSeconds,
+            args.approvalSignatures
+        );
+
+        // Query balances after fill and calculate amounts filled
+        FillResults memory fillResults = calculateFillResults(makerToken, takerToken, initialBalances);
+
+        // Validate that all taker tokens were sold
+        require(
+            fillResults.takerTokenFilledAmount == requestedFillAmount,
+            "ZeroExV2CoordinatorMultiOrderExchangeWrapper#exchange: Cannot sell enough taker token"
+        );
+
+        // Validate that max price is not violated
+        validateTradePrice(
+            priceRatio,
+            fillResults.takerTokenFilledAmount,
+            fillResults.makerTokenFilledAmount
+        );
+
+        // Ensure that the caller can take the makerTokens from this contract
+        makerToken.ensureAllowance(receiver, fillResults.makerTokenFilledAmount);
+
+        return fillResults.makerTokenFilledAmount;
+    }
+
+    /**
+     * Get amount of takerToken required to buy a certain amount of makerToken for a given trade.
+     * Should match the takerToken amount used in exchangeForAmount. If the order cannot provide
+     * exactly desiredMakerToken, then it must return the price to buy the minimum amount greater
+     * than desiredMakerToken
+     *
+     * @param  makerToken         Address of makerToken, the token to receive
+     * @param  takerToken         Address of takerToken, the token to pay
+     * @param  desiredMakerToken  Amount of makerToken requested
+     * @param  orderData          Arbitrary bytes data for any information to pass to the exchange
+     * @return                    Amount of takerToken the needed to complete the exchange
+     */
+    function getExchangeCost(
+        address makerToken,
+        address takerToken,
+        uint256 desiredMakerToken,
+        bytes calldata orderData
+    )
+        external
+        view
+        returns (uint256)
+    {}
+
+    /**
+     * Used to validate `Wallet` signatures for this contract within the 0x Exchange contract.
+     * This function will consider all hash and signature combinations as valid.
+     * @return Magic value required for a successful `Wallet` signature validation in the 0x Exchange v2.1 contract. 
+     */
+    function isValidSignature(
+        bytes32 /* hash */,
+        bytes calldata /* signature */
+    )
+        external
+        returns (bytes4)
+    {
+        // All signatures are always considered valid
+        // This contract should never hold a balance, but value can be passed through
+        return IS_VALID_WALLET_SIGNATURE_MAGIC_VALUE;
+    }
+
+    /**
+     * Gets maker and taker token balances of this contract.
+     */
+    function getMakerTakerTokenBalances(
+        address makerToken,
+        address takerToken
+    )
+        private
+        view
+        returns (MakerTakerTokenBalances memory balances)
+    {
+        address exchangeWrapper = address(this);
+        balances.makerTokenBalance = makerToken.balanceOf(exchangeWrapper);
+        balances.takerTokenBalance = takerToken.balanceOf(exchangeWrapper);
+        return balances;
+    }
+
+    /**
+     * Calculates the fill results based off of the delta in current balances and initial balances
+     * of the maker and taker tokens.
+     */
+    function calculateFillResults(
+        address makerToken,
+        address takerToken,
+        MakerTakerTokenBalances memory initialBalances
+    )
+        private
+        view
+        returns (FillResults memory fillResults)
+    {
+        MakerTakerTokenBalances memory currentBalances = getMakerTakerTokenBalances(makerToken, takerToken);
+        fillResults.makerTokenFilledAmount = currentBalances.makerTokenBalance.sub(initialBalances.makerTokenBalance);
+        fillResults.takerTokenFilledAmount = currentBalances.takerTokenBalance.sub(initialBalances.takerTokenBalance);
+        return fillResults;
+    }
+
+    /**
+     * Validates that a certain takerAmount and makerAmount are within the maxPrice bounds
+     */
+    function validateTradePrice(
+        TokenAmounts memory priceRatio,
+        uint256 takerAmount,
+        uint256 makerAmount
+    )
+        private
+        pure
+    {
+        require(
+            priceRatio.makerAmount == 0 ||
+            takerAmount.mul(priceRatio.makerAmount) <= makerAmount.mul(priceRatio.takerAmount),
+            "ZeroExV2CoordinatorMultiOrderExchangeWrapper#validateTradePrice: Price greater than maxPrice"
+        );
+    }
+}

--- a/contracts/exchange-wrappers/ZeroExV2CoordinatorMultiOrderExchangeWrapper.sol
+++ b/contracts/exchange-wrappers/ZeroExV2CoordinatorMultiOrderExchangeWrapper.sol
@@ -191,6 +191,9 @@ contract ZeroExV2CoordinatorMultiOrderExchangeWrapper is
             (TokenAmounts, CoordinatorArgs)
         );
 
+        // Validate that none of the coordinator approvals have expired
+        validateApprovalExpirationTimes(args.approvalExpirationTimeSeconds);
+    
         // Keep running count of how much takerToken is needed until desiredMakerToken is acquired
         TokenAmounts memory total;
         total.takerAmount = 0;
@@ -220,6 +223,7 @@ contract ZeroExV2CoordinatorMultiOrderExchangeWrapper is
         bytes calldata /* signature */
     )
         external
+        pure
         returns (bytes4)
     {
         // All signatures are always considered valid
@@ -393,6 +397,22 @@ contract ZeroExV2CoordinatorMultiOrderExchangeWrapper is
         fillResults.makerAmount = currentBalances.makerAmount.sub(initialBalances.makerAmount);
         fillResults.takerAmount = currentBalances.takerAmount.sub(initialBalances.takerAmount);
         return fillResults;
+    }
+
+    /**
+     * Validates that none of the coordinator approvals have expired
+     */
+    function validateApprovalExpirationTimes(uint256[] memory approvalExpirationTimeSeconds)
+        private
+        view
+    {
+        uint256 length = approvalExpirationTimeSeconds.length;
+        for (uint i = 0; i != length; i++) {
+            require(
+                approvalExpirationTimeSeconds[i] > block.timestamp,
+                "ZeroExV2CoordinatorMultiOrderExchangeWrapper#validateApprovalExpirationTimes: Expired approval"
+            );
+        }
     }
 
     /**

--- a/contracts/external/0x/v2/interfaces/ICoordinatorCore.sol
+++ b/contracts/external/0x/v2/interfaces/ICoordinatorCore.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.5.9;
+pragma experimental ABIEncoderV2;
+
+import "../libs/LibZeroExTransaction.sol";
+
+
+contract ICoordinatorCore {
+
+    /// @dev Executes a 0x transaction that has been signed by the feeRecipients that correspond to each order in the transaction's Exchange calldata.
+    /// @param transaction 0x transaction containing salt, signerAddress, and data.
+    /// @param txOrigin Required signer of Ethereum transaction calling this function.
+    /// @param transactionSignature Proof that the transaction has been signed by the signer.
+    /// @param approvalExpirationTimeSeconds Array of expiration times in seconds for which each corresponding approval signature expires.
+    /// @param approvalSignatures Array of signatures that correspond to the feeRecipients of each order in the transaction's Exchange calldata.
+    function executeTransaction(
+        LibZeroExTransaction.ZeroExTransaction memory transaction,
+        address txOrigin,
+        bytes memory transactionSignature,
+        uint256[] memory approvalExpirationTimeSeconds,
+        bytes[] memory approvalSignatures
+    )
+        public;
+}

--- a/contracts/external/0x/v2/libs/LibZeroExTransaction.sol
+++ b/contracts/external/0x/v2/libs/LibZeroExTransaction.sol
@@ -1,0 +1,29 @@
+/*
+
+  Copyright 2018 ZeroEx Intl.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+*/
+
+pragma solidity 0.5.9;
+
+
+contract LibZeroExTransaction
+{
+    struct ZeroExTransaction {
+        uint256 salt;                   // Arbitrary number to ensure uniqueness of transaction hash.
+        address signerAddress;          // Address of transaction signer.
+        bytes data;                     // AbiV2 encoded calldata.
+    }
+}


### PR DESCRIPTION
This PR implements the `ZeroExV2CoordinatorMultiOrderExchangeWrapper` contract, which adds compatibility for the 0x Coordinator contract. There are a few discussion points in the implementation:

- The amount of validation in this contract is a bit less than in the other 0x Exchange wrapper. This is mostly because we use `abi.decode` instead of parsing the `orderData` in assembly. `abi.decode` should fail if the input is malformed, but otherwise will have the same functionality.
- `getExchangeCost` is mostly copy/pasted from `ZeroExV2MultiOrderExchangeWrapper`. There are reasons that a fill may fail that are not checked in this function, but the calculations should be the same assuming the fill is valid. This can happen if a) the Coordinator approvals are improperly signed (can be determined 100% off-chain) or b) any of the approvals are expired (this is tricker). Do we want to fail fast in case b?
- This contract implements an `isValidSignature` function, which the 0x Exchange contract calls to determine if the 0x fill transaction is valid. Currently this function will always validate as `true`, which actually improves the fill UX by eliminating the need for 1 of 2 signatures. However, there are also good reasons for adding some authentication here (primarily spam resistance). If we want that, we can check that `ecrecover(hash, signature) == tx.origin`. Any preference here?